### PR TITLE
🐛 fix(config): write valid regex patterns on --init

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,8 @@ skip_chapters = ['avant', '1. opening credits', 'logos/opening credits', 'openin
 
 Regular expression patterns for subtitle lines to skip. Useful for removing song lyrics, sound effects, etc. Use single quotes to enclose patterns.
 
+Lines with no text (styling-only subtitles, or sound effects wrapped in `{}`, which subtitle formats treat as styling tags) are always skipped, even with an empty list of patterns.
+
 Default:
 
 ```toml
@@ -291,10 +293,9 @@ line_skip_patterns = [
   # Skip lines containing only '・～'
   '^・(～|〜)$',
   # Skip lines entirely enclosed in various types of brackets.
-  '^\\([^)]*\\)$',  # Parentheses ()
+  '^\([^)]*\)$',  # Parentheses ()
   '^（[^）]*）$',  # Full-width parentheses （）
-  '^\\[.*\\]$',  # Square brackets []
-  '^\\{[^\\}]*\\}$',  # Curly braces {}
+  '^\[.*\]$',  # Square brackets []
   '^<[^>]*>$',  # Angle brackets <>
 ]
 ```

--- a/shuku/cli.py
+++ b/shuku/cli.py
@@ -249,8 +249,8 @@ def process_file(
         subtitles = pysubs2.load(subtitle_path)
         line_skip_patterns = context.config["line_skip_patterns"]
         skip_patterns = [re.compile(pattern) for pattern in line_skip_patterns]
-        if skip_patterns:
-            filter_skip_patterns_in_place(subtitles, skip_patterns)
+        drop_empty_lines_in_place(subtitles)
+        filter_skip_patterns_in_place(subtitles, skip_patterns)
         skip_intervals = get_skipped_chapter_intervals(context)
         if skip_intervals:
             filter_chapters_in_place(subtitles, skip_intervals)
@@ -866,6 +866,18 @@ def filter_skip_patterns_in_place(
         for line in subs
         if not any(pattern.match(line.plaintext) for pattern in skip_patterns)
     ]
+
+
+def drop_empty_lines_in_place(subs: pysubs2.SSAFile) -> None:
+    """
+    Remove lines with no speech.
+
+    pysubs2 strips ASS override tags from plaintext, so {…} sound effects and
+    styling-only signs come through empty. They carry no text, but would still
+    contribute a segment to the condensed audio.
+    """
+    logging.debug("Dropping subtitle lines with no text…")
+    subs.events = [line for line in subs if line.plaintext.strip()]
 
 
 def get_skipped_chapter_intervals(context: Context) -> list[tuple[float, float]]:

--- a/shuku/config.py
+++ b/shuku/config.py
@@ -150,7 +150,6 @@ CONFIG_OPTIONS = {
             "^\\([^)]*\\)$",  # Parentheses ()
             "^（[^）]*）$",  # Full-width parentheses （）
             "^\\[.*\\]$",  # Square brackets []
-            "^\\{[^\\}]*\\}$",  # Curly braces {}
             "^<[^>]*>$",  # Angle brackets <>
         ],
         validators=[lambda x: all(isinstance(pattern, str) for pattern in x)],
@@ -439,6 +438,37 @@ def generate_config_content() -> str:
     return config_content.rstrip() + "\n"
 
 
+def toml_value(value: object) -> str:
+    """
+    Serialise a Python value as TOML.
+
+    Strings become TOML literal strings, which process no escape sequences. Do
+    not reach for repr(): its single-quoted output looks identical but is Python
+    syntax, where backslashes *are* escapes, so every regex backslash would be
+    doubled on the way out.
+
+    Literal strings cannot contain an apostrophe or a newline; such values are
+    rejected rather than escaped, since no value in CONFIG_OPTIONS needs them.
+    """
+    if isinstance(value, str):
+        if "'" in value or "\n" in value:
+            raise ValueError(
+                f"TOML literal string cannot contain ' or a newline: {value!r}"
+            )
+        return f"'{value}'"
+    # Must precede the int check: bool is a subclass of int.
+    if isinstance(value, bool):
+        return str(value).lower()
+    if isinstance(value, list):
+        return "[" + ", ".join(toml_value(item) for item in value) + "]"
+    if isinstance(value, dict):
+        pairs = (f"{toml_value(k)} = {toml_value(v)}" for k, v in value.items())
+        return "{ " + ", ".join(pairs) + " }"
+    if isinstance(value, (int, float)):
+        return str(value)
+    raise TypeError(f"Unsupported TOML value: {value!r}")
+
+
 def generate_item_content(key: str, item: ConfigItem) -> str:
     choices = list(map(str, item.choices or []))
     aliases = [
@@ -447,31 +477,17 @@ def generate_item_content(key: str, item: ConfigItem) -> str:
     choice_str = (
         f"# Choices: {', '.join(choices + aliases)}\n" if choices or aliases else ""
     )
-
-    def format_dict_with_equals(d: dict) -> str:
-        return "{ " + ", ".join(f'"{k}" = {repr(v)}' for k, v in d.items()) + " }"
-
-    example_value = (
-        (
-            format_dict_with_equals(item.example_value)
-            if isinstance(item.example_value, dict)
-            else repr(item.example_value)
+    if item.default_value is None:
+        # Show an example instead, commented out. It has to stay on one line:
+        # the '# ' prefix would only comment out the first one.
+        example = (
+            toml_value(item.example_value) if item.example_value is not None else "null"
         )
-        if getattr(item, "example_value", None)
-        else "null"
-    )
-    if key == "line_skip_patterns":
-        default_value_str = f"{key} = [\n"
-        default_value_str += "".join(
-            f"    {repr(pattern)},\n" for pattern in item.default_value
-        )
-        default_value_str += "]\n"
-    elif item.default_value is None:
-        default_value_str = f"# {key} = {example_value}\n"
-    elif isinstance(item.default_value, bool):
-        default_value_str = f"{key} = {str(item.default_value).lower()}\n"
-    elif isinstance(item.default_value, dict):
-        default_value_str = f"{key} = {format_dict_with_equals(item.default_value)}\n"
+        default_value_str = f"# {key} = {example}\n"
+    elif isinstance(item.default_value, list):
+        # One entry per line, so the list stays readable to edit by hand.
+        entries = "".join(f"    {toml_value(v)},\n" for v in item.default_value)
+        default_value_str = f"{key} = [\n{entries}]\n"
     else:
-        default_value_str = f"{key} = {repr(item.default_value)}\n"
+        default_value_str = f"{key} = {toml_value(item.default_value)}\n"
     return f"# {item.description}\n{choice_str}{default_value_str}\n"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -24,6 +24,7 @@ from shuku.cli import (
     create_concat_file,
     create_condensed_subtitles,
     display_and_select_stream,
+    drop_empty_lines_in_place,
     encode_final_audio,
     extract_season_and_episode,
     extract_specific_subtitle,
@@ -2436,6 +2437,60 @@ def test_main_processing_with_chapter_filtering(base_context):
         "Also should remain",
     ]
     assert [sub.text for sub in subs] == expected_texts
+
+
+def test_drop_empty_lines_removes_lines_with_no_plaintext():
+    subs = pysubs2.SSAFile()
+    test_lines = [
+        (1000, 2000, "{music}"),  # Stripped to nothing by pysubs2.
+        (3000, 4000, r"{\pos(320,240)}"),  # Styling-only sign.
+        (5000, 6000, "   "),  # Whitespace only.
+        (7000, 8000, "Real dialogue"),  # Should stay.
+    ]
+    for start, end, text in test_lines:
+        subs.events.append(pysubs2.SSAEvent(start=start, end=end, text=text))
+    drop_empty_lines_in_place(subs)
+    assert [sub.text for sub in subs] == ["Real dialogue"]
+
+
+def test_process_file_drops_empty_lines_without_skip_patterns(tmp_path):
+    video_path = str(tmp_path / "test.mkv")
+    Path(video_path).touch()
+    sub_path = str(tmp_path / "test.srt")
+    with open(sub_path, "w") as f:
+        f.write("""1
+00:00:01,000 --> 00:00:02,000
+{music}
+
+2
+00:00:03,000 --> 00:00:04,000
+Real dialogue""")
+    config = deepcopy(DEFAULT_CONFIG)
+    config["line_skip_patterns"] = []  # Empty lines are dropped regardless.
+    config["condensed_audio.enabled"] = False
+    config["condensed_video.enabled"] = False
+    config["condensed_subtitles.enabled"] = True
+    with (
+        patch("shuku.cli.FFmpeg"),
+        patch("shuku.cli.get_all_stream_info") as mock_stream_info,
+        patch("shuku.cli.find_subtitles", return_value=sub_path),
+    ):
+        mock_stream_info.return_value = {
+            "video": [],
+            "audio": [],
+            "subtitle": [],
+            "chapters": [],
+        }
+        args = argparse.Namespace(
+            subtitles=None,
+            output=None,
+            sub_track_id=None,
+            audio_track_id=None,
+            sub_delay=0,
+        )
+        process_file(video_path, config, args)
+        output_subs = pysubs2.load(str(tmp_path / "test (condensed).srt"))
+        assert [sub.text for sub in output_subs] == ["Real dialogue"]
 
 
 def test_process_file_with_chapter_filtering(tmp_path):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -14,11 +14,13 @@ from shuku.config import (
     ConfigItem,
     ConfigValidationError,
     dump_default_config,
+    flatten_dict,
     generate_config_content,
     generate_item_content,
     get_default_config_path,
     load_config,
     resolve_aliases,
+    toml_value,
     validate_bitrate_or_scale,
     validate_config,
 )
@@ -294,15 +296,12 @@ def test_generate_config_content():
         # Check default values.
         if item.default_value is None:
             assert "None" not in content
-        elif isinstance(item.default_value, bool):
-            assert f"{parts[-1]} = {str(item.default_value).lower()}" in content
-        elif key == "line_skip_patterns":
-            assert f"{parts[-1]} = [" in content
-            for pattern in item.default_value:
-                assert repr(pattern) in content
-            assert "]" in content
+        elif isinstance(item.default_value, list):
+            assert f"{parts[-1]} = [\n" in content
+            for entry in item.default_value:
+                assert f"    {toml_value(entry)},\n" in content
         else:
-            assert f"{parts[-1]} = {repr(item.default_value)}" in content
+            assert f"{parts[-1]} = {toml_value(item.default_value)}" in content
     # Check the file ends with a single newline.
     assert content.endswith("\n")
     assert not content.endswith("\n\n")
@@ -645,6 +644,36 @@ def test_validation_errors(codec, quality, expected_error):
     assert expected_error in str(exc_info.value)
 
 
+def test_generated_config_roundtrips():
+    expected = {
+        key: value for key, value in DEFAULT_CONFIG.items() if value is not None
+    }
+    parsed = flatten_dict(tomllib.loads(generate_config_content()))
+    assert parsed == expected
+
+
+# Values are emitted as TOML literal strings, which cannot contain an apostrophe
+# or a newline. Commented-out examples are invisible to the test above, so check
+# every value the generator can emit, not just the ones the document exposes.
+@pytest.mark.parametrize("item", CONFIG_OPTIONS.values(), ids=CONFIG_OPTIONS.keys())
+def test_config_values_roundtrip_as_toml(item):
+    for value in (item.default_value, item.example_value):
+        if value is not None:
+            assert tomllib.loads(f"value = {toml_value(value)}")["value"] == value
+
+
+@pytest.mark.parametrize("value", ["it's here", "line\nnext"])
+def test_toml_value_rejects_strings_it_cannot_represent(value):
+    with pytest.raises(ValueError, match="cannot contain"):
+        toml_value(value)
+
+
+@pytest.mark.parametrize("value", [None, {"a", "b"}, object()])
+def test_toml_value_rejects_unsupported_types(value):
+    with pytest.raises(TypeError, match="Unsupported TOML value"):
+        toml_value(value)
+
+
 def test_generate_item_content_with_dict_default_value():
     key = "my_key"
     item = ConfigItem(
@@ -654,7 +683,7 @@ def test_generate_item_content_with_dict_default_value():
     )
     result = generate_item_content(key, item)
     expected_output = """# My description
-my_key = { "key1" = 'value1', "key2" = 42 }
+my_key = { 'key1' = 'value1', 'key2' = 42 }
 
 """
     assert result == expected_output


### PR DESCRIPTION
## Summary

Two bugs stopped `line_skip_patterns` from working. This PR fixes both.

1. `shuku --init` wrote wrong patterns to the config file.

The code used Python's `repr()` to write TOML. This is the wrong function.
Python and TOML both write strings in single quotes, but the two are different.
Python processes backslash escapes. TOML literal strings do not.

Each backslash became two backslashes. The pattern `^\([^)]*\)$` was written as `'^\\([^)]*\\)$'`. TOML read this back as a different pattern. It matched no subtitle line.

A new function `toml_value()` writes TOML. It replaces all four `repr()` calls.
This deletes four special cases: the `line_skip_patterns` branch, the boolean branch, the dictionary branch, and the helper `format_dict_with_equals`.

2. Subtitle lines with no text were kept.

pysubs2 removes `{...}` tags from the subtitle text. A line that contains only `{music}` becomes empty. The default pattern `^\{[^\}]*\}$` cannot match an empty line. It has never removed a line.

The empty line then stays in the subtitles. `extract_speech_timing_from_subtitles` makes a segment from the start and end times of each line. It does not read the text. The result is a segment of audio with no speech.

A new function `drop_empty_lines_in_place()` removes lines with no text. It runs for all files. The default pattern for curly braces is deleted, because a line that it can match no longer reaches the filter.

**Behaviour change:** shuku now always removes subtitle lines with no text. This also applies when `line_skip_patterns` is empty. Styling only lines and `{...}` sound effects no longer add audio to the output. They also no longer appear in the condensed subtitles.

### Related issue

Resolves #152.

Bug 2 has no issue.

---

### How has this been tested?

- [ ] Manual tests
- [x] Unit tests
- [x] Integration tests

Each bug has a test that failed before the fix and passed after it:

| Test | Result before |
| --- | --- |
| `test_generated_config_roundtrips` | Backslashes were doubled |
| `test_config_values_roundtrip_as_toml` | Covers commented examples |
| `test_drop_empty_lines_removes_lines_with_no_plaintext` | No line was removed |
| `test_process_file_drops_empty_lines_without_skip_patterns` | Output was `['', 'Real dialogue']` |

---

### Type of change

- [x] Bug fix (fixes an issue without altering functionality)
- [ ] New feature (adds non-breaking functionality)
- [ ] Breaking change (alters existing functionality)
- [ ] UI/UX improvement (enhances user interface without altering functionality)
- [ ] Refactor (improves code quality without altering functionality)
- [ ] Documentation update
- [ ] Other (please describe below)

---

### Checklist

- [x] I have read the [**contributing guidelines**](https://github.com/welpo/shuku/blob/main/CONTRIBUTING.md).
- [x] I have formatted the code with [Ruff](https://docs.astral.sh/ruff/).
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.